### PR TITLE
Add timestamp conversion helper and pytest test

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -1,0 +1,5 @@
+from datetime import datetime
+
+def timestamp_to_apple(ts: float) -> datetime:
+    """Convert a Unix timestamp to Apple's NSDate (offset from 2001-01-01)."""
+    return datetime.fromtimestamp(ts) + (datetime(2001, 1, 1) - datetime.fromtimestamp(0))

--- a/tests/test_timestamp.py
+++ b/tests/test_timestamp.py
@@ -1,0 +1,5 @@
+from datetime import datetime
+from helper import timestamp_to_apple
+
+def test_unix_epoch_converts_to_apple_epoch():
+    assert timestamp_to_apple(0) == datetime(2001, 1, 1)


### PR DESCRIPTION
## Summary
- implement helper.timestamp_to_apple conversion function
- add pytest with known epoch test

## Testing
- `pytest -q` *(fails: command not found)*
- `python3 -m pytest -q` *(fails: No module named pytest)*